### PR TITLE
Remove -logtostderr from Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN apk add --update -t build-deps go git mercurial \
     && rm -rf /go && apk del --purge build-deps
 
 EXPOSE     9108 9109
-ENTRYPOINT [ "/bin/graphite_exporter", "-logtostderr" ]
+ENTRYPOINT [ "/bin/graphite_exporter" ]


### PR DESCRIPTION
graphite_exporter has been migrated to github.com/prometheus/log, which
logs to stdout by default.