### PR TITLE
New Dockerfile using alpine-golang-make-onbuild base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM        sdurrheimer/alpine-golang-make-onbuild
 MAINTAINER  The Prometheus Authors <prometheus-developers@googlegroups.com>
 
-EXPOSE      9108 9109
+EXPOSE      9108 9109 9109/udp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,4 @@
-FROM alpine:3.1
-MAINTAINER The Prometheus Authors <prometheus-developers@googlegroups.com>
+FROM        sdurrheimer/alpine-golang-make-onbuild
+MAINTAINER  The Prometheus Authors <prometheus-developers@googlegroups.com>
 
-ENV GOPATH /go
-COPY . /go/src/github.com/prometheus/graphite_exporter
-
-RUN apk add --update -t build-deps go git mercurial \
-    && apk add -u musl && rm -rf /var/cache/apk/* \
-    && go get github.com/tools/godep \
-    && cd /go/src/github.com/prometheus/graphite_exporter \
-    && go get -d && go build -o /bin/graphite_exporter \
-    && rm -rf /go && apk del --purge build-deps
-
-EXPOSE     9108 9109
-ENTRYPOINT [ "/bin/graphite_exporter" ]
+EXPOSE      9108 9109

--- a/Makefile.COMMON
+++ b/Makefile.COMMON
@@ -49,19 +49,22 @@ ifeq ($(GOOS),darwin)
 endif
 
 GO_VERSION ?= 1.4.2
-
-ifeq ($(shell type go >/dev/null && go version | sed 's/.*go\([0-9.]*\).*/\1/'), $(GO_VERSION))
-	GOROOT := $(shell go env GOROOT)
-else
-	GOROOT := $(CURDIR)/.build/go$(GO_VERSION)
-endif
-
 GOURL      ?= https://golang.org/dl
 GOPKG      ?= go$(GO_VERSION).$(GOOS)-$(GOARCH)$(RELEASE_SUFFIX).tar.gz
 GOPATH     := $(CURDIR)/.build/gopath
-GOCC       ?= $(GOROOT)/bin/go
-GO         ?= GOROOT=$(GOROOT) GOPATH=$(GOPATH) $(GOCC)
-GOFMT      ?= $(GOROOT)/bin/gofmt
+
+# Check for the correct version of go in the path. If we find it, use it.
+# Otherwise, prepare to build go locally.
+ifeq ($(shell command -v "go" >/dev/null && go version | sed -e 's/^[^0-9.]*\([0-9.]*\).*/\1/'), $(GO_VERSION))
+	GOCC   ?= $(shell command -v "go")
+	GOFMT  ?= $(shell command -v "gofmt")
+	GO     ?= GOPATH=$(GOPATH) $(GOCC)
+else
+	GOROOT ?= $(CURDIR)/.build/go$(GO_VERSION)
+	GOCC   ?= $(GOROOT)/bin/go
+	GOFMT  ?= $(GOROOT)/bin/gofmt
+	GO     ?= GOROOT=$(GOROOT) GOPATH=$(GOPATH) $(GOCC)
+endif
 
 # Never honor GOBIN, should it be set at all.
 unexport GOBIN

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 An exporter for metrics exported in the [Graphite plaintext
 protocol](http://graphite.readthedocs.org/en/latest/feeding-carbon.html#the-plaintext-protocol).
 It accepts data over both TCP and UDP, and transforms and exposes them for
-consumption by Prometheus. 
+consumption by Prometheus.
 
 This exporter is useful for exporting metrics from existing Graphite setups, as
 well as for metrics which are not covered by the core Prometheus exporters such
@@ -72,3 +72,17 @@ follows:
 
     test.web-server.foo.bar
      => test_web__server_foo_bar{}
+
+## Using Docker
+
+You can deploy this exporter using the [prom/graphite-exporter](https://registry.hub.docker.com/u/prom/graphite-exporter/) Docker image.
+
+For example:
+
+```bash
+docker pull prom/graphite-exporter
+
+docker run -d -p 9108:9108 -p 9109:9109 -p 9109/udp:9109/udp
+        -v $PWD/graphite_mapping.conf:/tmp/graphite_mapping.conf \
+        prom/graphite-exporter -graphite.mapping-config=/tmp/graphite_mapping.conf
+```

--- a/main.go
+++ b/main.go
@@ -236,5 +236,7 @@ func main() {
       </body>
       </html>`))
 	})
+
+	log.Infof("Starting Server: %s", *listeningAddress)
 	http.ListenAndServe(*listeningAddress, nil)
 }


### PR DESCRIPTION
Following the docker related PR series.

New Dockerfile using the [alpine-golang-make-onbuild](https://github.com/sdurrheimer/alpine-golang-make-onbuild) base image whose goal is to unified the way to dockerize prometheus tools and exporters based on Golang.

The binary is build using make. (Golang is installed via make too, respecting the GO_VERSION).

A testable image is available under my name on Docker hub : [Link](https://registry.hub.docker.com/u/sdurrheimer/graphite-exporter/)

I have also added some Docker usage instructions in the readme.

As always, the [alpine-golang-make-onbuild](https://github.com/sdurrheimer/alpine-golang-make-onbuild)  image can be also move under Prometheus organization.

@brian-brazil @discordianfish 