### PR TITLE
Add flag to drop metrics that don't match the mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ Metrics that don't match any mapping in the configuration file are translated
 into Prometheus metrics without any labels and with certain characters escaped
 (`_` -> `__`; `-` -> `__`; `.` -> `_`).
 
+If you have a very large set of metrics you may want to skip the ones that don't
+match the mapping configuration. If that is the case you can force this behaviour
+using the `-graphite.mapping-strict-match` flag, and it will only store those metrics
+you really want.
+
 An example mapping configuration:
 
     test.dispatcher.*.*.*

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ var (
 	graphiteAddress  = flag.String("graphite.listen-address", ":9109", "TCP and UDP address on which to accept samples.")
 	mappingConfig    = flag.String("graphite.mapping-config", "", "Metric mapping configuration file name.")
 	sampleExpiry     = flag.Duration("graphite.sample-expiry", 5*time.Minute, "How long a sample is valid for.")
+	strictMatch      = flag.Bool("graphite.mapping-strict-match", false, "Only store metrics that match the mapping configuration.")
 	lastProcessed    = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "graphite_last_processed_timestamp_seconds",
@@ -96,6 +97,10 @@ func (c *graphiteCollector) processLine(line string) {
 		name = labels["name"]
 		delete(labels, "name")
 	} else {
+		// If graphite.mapping-strict-match flag is set, we will drop this metric.
+		if *strictMatch {
+			return
+		}
 		name = invalidMetricChars.ReplaceAllString(parts[0], "_")
 	}
 


### PR DESCRIPTION
Hello there!

First of all, thanks for your work on this, it is a very useful tool :+1: 

We have a very large data set of metrics and we are trying to forward small subsets of metrics onto a different processing/analytics storage, but we don't want all the metrics. We only want those metrics that matches our mapping file configuration.

I added just a bunch of lines to enable that behaviour.

Cheers!