### PR TITLE
allow user-defined regular expressions

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ var (
 	mappingConfig    = flag.String("graphite.mapping-config", "", "Metric mapping configuration file name.")
 	sampleExpiry     = flag.Duration("graphite.sample-expiry", 5*time.Minute, "How long a sample is valid for.")
 	strictMatch      = flag.Bool("graphite.mapping-strict-match", false, "Only store metrics that match the mapping configuration.")
+	allowUserRegex   = flag.Bool("graphite.allow-user-regex", false, "Treat metric lines as user-specified regular expressions")
 	lastProcessed    = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "graphite_last_processed_timestamp_seconds",
@@ -186,7 +187,7 @@ func main() {
 
 	c.mapper = &metricMapper{}
 	if *mappingConfig != "" {
-		err := c.mapper.initFromFile(*mappingConfig)
+		err := c.mapper.initFromFile(*mappingConfig, *allowUserRegex)
 		if err != nil {
 			log.Fatalf("Error loading metric mapping config: %s", err)
 		}

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ var (
 	mappingConfig    = flag.String("graphite.mapping-config", "", "Metric mapping configuration file name.")
 	sampleExpiry     = flag.Duration("graphite.sample-expiry", 5*time.Minute, "How long a sample is valid for.")
 	strictMatch      = flag.Bool("graphite.mapping-strict-match", false, "Only store metrics that match the mapping configuration.")
-	allowUserRegex   = flag.Bool("graphite.allow-user-regex", false, "Treat metric lines as user-specified regular expressions")
+	allowUserRegex   = flag.Bool("graphite.allow-user-regex", false, "Allow user-specified regular expressions on lines with :userRegExp: prefix")
 	lastProcessed    = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "graphite_last_processed_timestamp_seconds",

--- a/mapper.go
+++ b/mapper.go
@@ -66,7 +66,8 @@ func (m *metricMapper) initFromString(fileContents string, allowUserRegex bool) 
 
 			if strings.HasPrefix(line, prefix) {
 				if allowUserRegex {
-					fmt.Println(strings.Trim(line[len(prefix):], " "))
+					// we have a user-defined regular expression, so use it as 
+					// raw regex and hope that it is constructed properly
 					currentMapping.regex = regexp.MustCompile(strings.Trim(line[len(prefix):], " "))
 				}
 			} else if metricLineRE.MatchString(line) {

--- a/mapper.go
+++ b/mapper.go
@@ -75,14 +75,14 @@ func (m *metricMapper) initFromString(fileContents string, allowUserRegex bool) 
 			}
 
 			if !userRegex {
-			// Translate the glob-style metric match line into a proper regex that we
-			// can use to match metrics later on.
-			metricRe := strings.Replace(line, ".", "\\.", -1)
-			metricRe = strings.Replace(metricRe, "*", "([^.]+)", -1)
-			currentMapping.regex = regexp.MustCompile("^" + metricRe + "$")
+				// Translate the glob-style metric match line into a proper regex that we
+				// can use to match metrics later on.
+				metricRe := strings.Replace(line, ".", "\\.", -1)
+				metricRe = strings.Replace(metricRe, "*", "([^.]+)", -1)
+				currentMapping.regex = regexp.MustCompile("^" + metricRe + "$")
 			} else {
 				currentMapping.regex = regexp.MustCompile(line)
-			}	
+			}
 			state = METRIC_DEFINITION
 
 		case METRIC_DEFINITION:
@@ -123,7 +123,6 @@ func (m *metricMapper) initFromFile(fileName string, userRegex bool) error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("userRegex is %s", userRegex)
 	return m.initFromString(string(mappingStr), userRegex)
 }
 

--- a/mapper.go
+++ b/mapper.go
@@ -28,7 +28,6 @@ var (
 	labelLineRE       = regexp.MustCompile(`^([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*"(.*)"$`)
 	invalidNameCharRE = regexp.MustCompile(`[^a-zA-Z0-9:_]`)
 	validNameRE       = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9:_]*$`)
-	userRegex         = false
 	prefix            = ":userRegExp:"
 )
 


### PR DESCRIPTION
The default simple regex can be too restrictive -- for example, it makes it impossible to import any of the graphite-exported hadoop metrics because they start with a "." and contain standard hostnames.

Here I've modified the metric line parsing to allow for arbitrary user-defined regular expressions on lines that begin with ":userRegExp:" -- all other metric specifications are treated like before. 
