### PR TITLE
Allow mappings that begin with .

### DIFF
--- a/mapper.go
+++ b/mapper.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	metricLineRE      = regexp.MustCompile(`^(\*\.|[^*.]+\.)*(\*|[^*.]+)$`)
+	metricLineRE      = regexp.MustCompile(`^(\*\.|[^*.]+\.|\.)*(\*|[^*.]+)$`)
 	labelLineRE       = regexp.MustCompile(`^([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*"(.*)"$`)
 	invalidNameCharRE = regexp.MustCompile(`[^a-zA-Z0-9:_]`)
 	validNameRE       = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9:_]*$`)
@@ -61,6 +61,7 @@ func (m *metricMapper) initFromString(fileContents string) error {
 			if line == "" {
 				continue
 			}
+
 			if !metricLineRE.MatchString(line) {
 				return fmt.Errorf("Line %d: expected metric match line, got: %s", i, line)
 			}

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -72,6 +72,66 @@ func TestMetricMapper(t *testing.T) {
 				},
 			},
 		},
+		// Config with name sanitized without specified group.
+		{
+			config: `
+				.*.*.test.*
+				name="no_group"
+				first="$1"
+				second="$2"
+				third="$3"
+				job="$1-$2-$3"
+			`,
+			mappings: map[string]map[string]string{
+				".1.2.test.3": {
+					"name":   "no_group",
+					"first":  "1",
+					"second": "2",
+					"third":  "3",
+					"job":    "1-2-3",
+				},
+			},
+		},
+		// Config with name sanitized without specified group and type.
+		{
+			config: `
+				..*.*.test.*
+				name="no_group_and_type"
+				first="$1"
+				second="$2"
+				third="$3"
+				job="$1-$2-$3"
+			`,
+			mappings: map[string]map[string]string{
+				"..1.2.test.3": {
+					"name":   "no_group_and_type",
+					"first":  "1",
+					"second": "2",
+					"third":  "3",
+					"job":    "1-2-3",
+				},
+			},
+		},
+		// Config with empty components.
+		{
+			config: `
+				.*.*..test..*
+				name="empty_components"
+				first="$1"
+				second="$2"
+				third="$3"
+				job="$1-$2-$3"
+			`,
+			mappings: map[string]map[string]string{
+				".1.2..test..3": {
+					"name":   "empty_components",
+					"first":  "1",
+					"second": "2",
+					"third":  "3",
+					"job":    "1-2-3",
+				},
+			},
+		},
 		// Config with single component.
 		{
 			config: `


### PR DESCRIPTION
Graphite metric names that begin with a dot '.' (ex. .*.*.test) are not mapped with respect to associated mapping defined in config file. See more details [here](https://github.com/prometheus/graphite_exporter/issues/13). In graphite, the initial dot is appended to the metric name when the user does not specify a group name for the metric.

I doubt users switching to Prometheus from Graphite would be interested in changing their metric names to include a group name as it would create a new time series without original time series' datapoints. Thus, this case can be handled by graphite_exporter with a small change to the regex that checks for valid mappings.