### PR TITLE
Use golang-builder base image for tests in CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -44,7 +44,7 @@ deployment:
       - docker push $DOCKER_IMAGE_NAME
       - docker push $QUAY_IMAGE_NAME
   hub_tag:
-    tag: /^[0-9]+(\.[0-9]+){2}(-.+|[^-.]*)$/
+    tag: /^v[0-9]+(\.[0-9]+){2}(-.+|[^-.]*)$/
     owner: prometheus
     commands:
       - promu crossbuild tarballs
@@ -53,7 +53,7 @@ deployment:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
       - docker login -e $QUAY_EMAIL -u $QUAY_LOGIN -p $QUAY_PASSWORD quay.io
       - |
-        if [[ "$CIRCLE_TAG" =~ ^[0-9]+(\.[0-9]+){2}$ ]]; then
+        if [[ "$CIRCLE_TAG" =~ ^v[0-9]+(\.[0-9]+){2}$ ]]; then
           docker tag "$DOCKER_IMAGE_NAME:$CIRCLE_TAG" "$DOCKER_IMAGE_NAME:latest"
           docker tag "$QUAY_IMAGE_NAME:$CIRCLE_TAG" "$QUAY_IMAGE_NAME:latest"
         fi

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   environment:
     DOCKER_IMAGE_NAME: prom/graphite-exporter
     QUAY_IMAGE_NAME: quay.io/prometheus/graphite-exporter
-    DOCKER_TEST_IMAGE_NAME: quay.io/prometheus/golang-builder:1.6-main
+    DOCKER_TEST_IMAGE_NAME: quay.io/prometheus/golang-builder:1.6-base
     REPO_PATH: github.com/prometheus/graphite_exporter
   pre:
     - sudo curl -L -o /usr/bin/docker 'https://s3-external-1.amazonaws.com/circle-downloads/docker-1.9.1-circleci'


### PR DESCRIPTION
Must be merged after prometheus/golang-builder#13 and prometheus/promu#41 have been merged and successfully built.