### PR TITLE
Fix typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ you really want.
 An example mapping configuration:
 
     test.dispatcher.*.*.*
-    name="dispatcher_events"
+    name="dispatcher_events_total"
     processor="$1"
     action="$2"
     outcome="$3"
     job="test_dispatcher"
 
     *.signup.*.*
-    name="signup_events"
+    name="signup_events_total"
     provider="$2"
     outcome="$3"
     job="${1}_server"
@@ -74,10 +74,10 @@ This would transform these example graphite metrics into Prometheus metrics as
 follows:
 
     test.dispatcher.FooProcessor.send.success
-     => dispatcher_events{processor="FooProcessor", action="send", outcome="success", job="test_dispatcher"}
+     => dispatcher_events_total{processor="FooProcessor", action="send", outcome="success", job="test_dispatcher"}
 
     foo_product.signup.facebook.failure
-     => signup_events_counter{provider="facebook", outcome="failure", job="foo_product_server"}
+     => signup_events_total{provider="facebook", outcome="failure", job="foo_product_server"}
 
     test.web-server.foo.bar
      => test_web__server_foo_bar{}


### PR DESCRIPTION
The name of the metric from the example mapping does not match what is written down below in the transformed form. cc/ @brian-brazil 