### PR TITLE
main: return 404 in the root HTTP handler iff path is not "/"

### DIFF
--- a/main.go
+++ b/main.go
@@ -295,6 +295,10 @@ func main() {
 	}()
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
 		w.Write([]byte(`<html>
       <head><title>Graphite Exporter</title></head>
       <body>


### PR DESCRIPTION
Return 404 in the root HTTP handler iff the path is not "/" so that the
users would be able to access other end-points such as
"/debug/pprof/heap" and so on.

Unblocks work on issue https://github.com/prometheus/graphite_exporter/issues/66.