### PR TITLE
Switch to sync.Map to improve performance when under lots of load

### DIFF
--- a/main.go
+++ b/main.go
@@ -180,7 +180,7 @@ func (c *graphiteCollector) processSamples() {
 }
 
 // Collect implements prometheus.Collector.
-func (c graphiteCollector) Collect(ch chan<- prometheus.Metric) {
+func (c *graphiteCollector) Collect(ch chan<- prometheus.Metric) {
 	ch <- lastProcessed
 
 	samples := make([]*graphiteSample, 0, c.numsamples)
@@ -207,7 +207,7 @@ func (c graphiteCollector) Collect(ch chan<- prometheus.Metric) {
 }
 
 // Describe implements prometheus.Collector.
-func (c graphiteCollector) Describe(ch chan<- *prometheus.Desc) {
+func (c *graphiteCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- lastProcessed.Desc()
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -123,10 +123,8 @@ func TestProcessLine(t *testing.T) {
 	c.ch <- nil
 	for _, k := range testCases {
 		originalName := strings.Split(k.line, " ")[0]
-		data, ok := c.samples.Load(originalName)
-		assert.Equal(t, ok, true)
-		sample, ok := data.(*graphiteSample)
-		assert.Equal(t, ok, true)
+		data, _ := c.samples.Load(originalName)
+		sample, _ := data.(*graphiteSample)
 
 		if k.willFail {
 			assert.Nil(t, sample, "Found %s", k.name)

--- a/main_test.go
+++ b/main_test.go
@@ -123,7 +123,11 @@ func TestProcessLine(t *testing.T) {
 	c.ch <- nil
 	for _, k := range testCases {
 		originalName := strings.Split(k.line, " ")[0]
-		sample := c.samples[originalName]
+		data, ok := c.samples.Load(originalName)
+		assert.Equal(t, ok, true)
+		sample, ok := data.(*graphiteSample)
+		assert.Equal(t, ok, true)
+
 		if k.willFail {
 			assert.Nil(t, sample, "Found %s", k.name)
 		} else {


### PR DESCRIPTION
Part of https://github.com/prometheus/graphite_exporter/issues/66. The idea behind this change is to lock the map per key but not per the whole instance.
Also, switch a few methods so that there would be no copying of `sync.Map`. That might have improved the performance as well because there are less map copying.

After:
[profilev2.pdf](https://github.com/prometheus/graphite_exporter/files/2653061/profilev2.pdf)

Before:
[profiling_output.pdf](https://github.com/prometheus/graphite_exporter/files/2653062/profiling_output.pdf)

I don't have the graphs for lengths of how long it took to download `/metrics` with ~500k metrics but now it seems that the lengths are much more consistent even though they still take a long time. It used to jump from ~2s. to ~30s. With this change it consistently takes around ~10s. which would you expect to happen since the stress testing program pushes new metrics each 10 seconds.