### PR TITLE
Fix go.sum after Go1.11.4 bump

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -26,7 +26,7 @@ github.com/prometheus/client_model v0.0.0-20150212101744-fa8ad6fec335 h1:0E/5GnG
 github.com/prometheus/client_model v0.0.0-20150212101744-fa8ad6fec335/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/common v0.0.0-20170731114204-61f87aac8082 h1:M/45ksQhBkhxI65UXRNvyuF6sV7A08GMYk39aGZQlJQ=
 github.com/prometheus/common v0.0.0-20170731114204-61f87aac8082/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
-github.com/prometheus/procfs v0.0.0-20160411190841-abf152e5f3e9 h1:IrO4Eb9oGw+GxzOhO4b2QC5EWO85Omh/4iTSPZktMm8=
+github.com/prometheus/procfs v0.0.0-20160411190841-abf152e5f3e9 h1:ex32PG6WhE5zviWS08vcXTwX2IkaH9zpeYZZvrmj3/U=
 github.com/prometheus/procfs v0.0.0-20160411190841-abf152e5f3e9/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/statsd_exporter v0.8.0 h1:YJhXIPjOTtf5q1HMrlQ8N39ZGB55bBvD3m5maJdNzbs=
 github.com/prometheus/statsd_exporter v0.8.0/go.mod h1:4Ufwk0514k6PHiVtIVn5jBaNXnWfDw1T4VT1kQOF47w=


### PR DESCRIPTION
The latest Go version (1.11.4) breaks the build process because it changes the checksum of the `github.com/prometheus/procfs` module. See https://github.com/golang/go/issues/29278#issuecomment-447537558 for the details.