### PR TITLE
Accept 'name' as a label

### DIFF
--- a/main.go
+++ b/main.go
@@ -120,7 +120,6 @@ func (c *graphiteCollector) processLine(line string) {
 		return
 	}
 
-	delete(labels, "name")
 	if present {
 		name = invalidMetricChars.ReplaceAllString(mapping.Name, "_")
 	} else {

--- a/main_test.go
+++ b/main_test.go
@@ -46,8 +46,9 @@ func TestProcessLine(t *testing.T) {
 			line: "my.simple.metric 9001 1534620625",
 			name: "my_simple_metric",
 			labels: map[string]string{
-				"foo": "bar",
-				"zip": "zot",
+				"foo":  "bar",
+				"zip":  "zot",
+				"name": "alabel",
 			},
 			present: true,
 			value:   float64(9001),


### PR DESCRIPTION
@matthiasr 
Fix issue #39 
Since pull request #52, graphite_Exporter use the statd_exporter.
A mapping label should now be able to be named "name". There's a check in main.go that prevent it.

I've remove the unwanted line.