### PR TITLE
Fixed panic on bad runtime flags.

### DIFF
--- a/main.go
+++ b/main.go
@@ -230,7 +230,7 @@ func init() {
 
 func dumpFSM(mapper *mapper.MetricMapper, dumpFilename string, logger log.Logger) error {
 	if mapper.FSM == nil {
-		return fmt.Errorf("FSM is not available. Posible due to the presence of regex patterns")
+		return fmt.Errorf("no FSM available to be dumped, possibly because the mapping contains regex patterns")
 	}
 	f, err := os.Create(dumpFilename)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -229,6 +229,9 @@ func init() {
 }
 
 func dumpFSM(mapper *mapper.MetricMapper, dumpFilename string, logger log.Logger) error {
+	if mapper.FSM == nil {
+		return fmt.Errorf("FSM is not available. Posible due to the presence of regex patterns")
+	}
 	f, err := os.Create(dumpFilename)
 	if err != nil {
 		return err


### PR DESCRIPTION
An FSM is not generated if you use a matching regex.

Signed-off-by: Joaquin Fernandez Campo <jfcampo@gmail.com>