### PR TITLE
[36] initial support for tagged graphite metrics

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,11 @@
 run:
   modules-download-mode: vendor
-
+  skip-dirs:
+    - vendor
+    - e2e
 # Run only staticcheck for now. Additional linters will be enabled one-by-one.
 linters:
   enable:
   - staticcheck
+  - goimports
   disable-all: true

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -46,7 +46,7 @@ func TestIssue61(t *testing.T) {
 	}
 	defer exporter.Process.Kill()
 
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 20; i++ {
 		if i > 0 {
 			time.Sleep(1 * time.Second)
 		}
@@ -92,6 +92,8 @@ rspamd.spam_count 3 NOW`
 	if err != nil {
 		t.Fatalf("write error: %v", err)
 	}
+
+	time.Sleep(5 * time.Second)
 
 	resp, err := http.Get("http://" + path.Join(webAddr, "metrics"))
 	if err != nil {

--- a/e2e/issue90_test.go
+++ b/e2e/issue90_test.go
@@ -83,6 +83,8 @@ func TestIssue90(t *testing.T) {
 		conn.Close()
 	}
 
+	time.Sleep(5 * time.Second)
+
 	resp, err := http.Get("http://" + path.Join(webAddr, "metrics"))
 	if err != nil {
 		t.Fatalf("get error: %v", err)

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	_ "net/http/pprof"
 	"os"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -63,13 +64,60 @@ var (
 			Help: "How long in seconds a metric sample is valid for.",
 		},
 	)
+	tagParseFailures = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "graphite_tag_parse_failures",
+			Help: "Total count of samples with invalid tags",
+		})
+	invalidMetrics = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "graphite_invalid_metrics",
+			Help: "Total count of metrics dropped due to mismatched label keys",
+		})
 	invalidMetricChars = regexp.MustCompile("[^a-zA-Z0-9_:]")
+
+	metricNameKeysIndex = newMetricNameAndKeys()
 )
+
+// metricNameAndKeys is a cache of metric names and the label keys previously used
+type metricNameAndKeys struct {
+	mtx   sync.Mutex
+	cache map[string]string
+}
+
+func newMetricNameAndKeys() *metricNameAndKeys {
+	x := metricNameAndKeys{
+		cache: make(map[string]string),
+	}
+	return &x
+}
+
+func keysFromLabels(labels prometheus.Labels) string {
+	labelKeys := make([]string, len(labels))
+	for k, _ := range labels {
+		labelKeys = append(labelKeys, k)
+	}
+	sort.Strings(labelKeys)
+	return strings.Join(labelKeys, ",")
+}
+
+// checkNameAndKeys returns true if metric has the same label keys or is new, false if not
+func (c *metricNameAndKeys) checkNameAndKeys(name string, labels prometheus.Labels) bool {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	providedKeys := keysFromLabels(labels)
+	if keys, found := c.cache[name]; found {
+		return keys == providedKeys
+	}
+
+	c.cache[name] = providedKeys
+	return true
+}
 
 type graphiteSample struct {
 	OriginalName string
 	Name         string
-	Labels       map[string]string
+	Labels       prometheus.Labels
 	Help         string
 	Value        float64
 	Type         prometheus.ValueType
@@ -126,6 +174,37 @@ func (c *graphiteCollector) processLines() {
 	}
 }
 
+func parseMetricNameAndTags(name string, labels prometheus.Labels) (string, error) {
+	if strings.ContainsRune(name, ';') {
+		// name contains tags - parse tags and add to labels
+		if strings.Count(name, ";") != strings.Count(name, "=") {
+			tagParseFailures.Inc()
+			return name, fmt.Errorf("error parsing tags on %s", name)
+		}
+
+		parts := strings.Split(name, ";")
+		parsedName := parts[0]
+		tags := parts[1:]
+
+		for _, tag := range tags {
+			kv := strings.SplitN(tag, "=", 2)
+			if len(kv) != 2 {
+				// we may have added bad labels already...
+				tagParseFailures.Inc()
+				return name, fmt.Errorf("error parsing tags on %s", name)
+			}
+
+			k := kv[0]
+			v := kv[1]
+			labels[k] = v
+		}
+
+		return parsedName, nil
+	}
+
+	return name, nil
+}
+
 func (c *graphiteCollector) processLine(line string) {
 	line = strings.TrimSpace(line)
 	level.Debug(c.logger).Log("msg", "Incoming line", "line", line)
@@ -136,16 +215,42 @@ func (c *graphiteCollector) processLine(line string) {
 	}
 	originalName := parts[0]
 	var name string
-	mapping, labels, present := c.mapper.GetMapping(originalName, mapper.MetricTypeGauge)
+	var err error
+	mapping, labels, mappingPresent := c.mapper.GetMapping(originalName, mapper.MetricTypeGauge)
 
-	if (present && mapping.Action == mapper.ActionTypeDrop) || (!present && c.strictMatch) {
+	if (mappingPresent && mapping.Action == mapper.ActionTypeDrop) || (!mappingPresent && c.strictMatch) {
 		return
 	}
 
-	if present {
+	if mappingPresent {
+		parsedLabels := make(prometheus.Labels)
+		_, err = parseMetricNameAndTags(originalName, parsedLabels)
+		if err != nil {
+			level.Info(c.logger).Log("msg", "Invalid tags", "line", line)
+			return
+		}
+
 		name = invalidMetricChars.ReplaceAllString(mapping.Name, "_")
+		// check to ensure the same tags are present
+		if validKeys := metricNameKeysIndex.checkNameAndKeys(name, parsedLabels); !validKeys {
+			level.Info(c.logger).Log("msg", "Dropped because metric keys do not match previously used keys", "line", line)
+			invalidMetrics.Inc()
+			return
+		}
 	} else {
-		name = invalidMetricChars.ReplaceAllString(originalName, "_")
+		labels = make(prometheus.Labels)
+		name, err = parseMetricNameAndTags(originalName, labels)
+		if err != nil {
+			level.Info(c.logger).Log("msg", "Invalid tags", "line", line)
+			return
+		}
+		name = invalidMetricChars.ReplaceAllString(name, "_")
+		// check to ensure the same tags are present
+		if validKeys := metricNameKeysIndex.checkNameAndKeys(name, labels); !validKeys {
+			level.Info(c.logger).Log("msg", "Dropped because metric keys do not match previously used keys", "line", line)
+			invalidMetrics.Inc()
+			return
+		}
 	}
 
 	value, err := strconv.ParseFloat(parts[1], 64)
@@ -158,6 +263,7 @@ func (c *graphiteCollector) processLine(line string) {
 		level.Info(c.logger).Log("msg", "Invalid timestamp", "line", line)
 		return
 	}
+
 	sample := graphiteSample{
 		OriginalName: originalName,
 		Name:         name,
@@ -257,6 +363,8 @@ func main() {
 	logger := promlog.New(promlogConfig)
 
 	prometheus.MustRegister(sampleExpiryMetric)
+	prometheus.MustRegister(tagParseFailures)
+	prometheus.MustRegister(invalidMetrics)
 	sampleExpiryMetric.Set(sampleExpiry.Seconds())
 
 	level.Info(logger).Log("msg", "Starting graphite_exporter", "version_info", version.Info())

--- a/main_test.go
+++ b/main_test.go
@@ -89,7 +89,7 @@ func TestProcessLine(t *testing.T) {
 		{
 			line:          "my.nomap.metric.novalue 9001 ",
 			name:          "my_nomap_metric_novalue",
-			mappingLabels: nil,
+			mappingLabels: prometheus.Labels{},
 			value:         float64(9001),
 			willFail:      true,
 		},
@@ -104,6 +104,7 @@ func TestProcessLine(t *testing.T) {
 			line:           "my.mapped.strict.metric 55 1534620625",
 			name:           "my_mapped_strict_metric",
 			value:          float64(55),
+			mappingLabels:  prometheus.Labels{},
 			mappingPresent: true,
 			willFail:       false,
 			strict:         true,

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -1,0 +1,142 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"bufio"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus/graphite_exporter/pkg/graphitesample"
+	"github.com/prometheus/graphite_exporter/pkg/line"
+	"github.com/prometheus/graphite_exporter/pkg/metricmapper"
+)
+
+type graphiteCollector struct {
+	Mapper             metricmapper.MetricMapper
+	Samples            map[string]*graphitesample.GraphiteSample
+	mu                 *sync.Mutex
+	SampleCh           chan *graphitesample.GraphiteSample
+	lineCh             chan string
+	StrictMatch        bool
+	sampleExpiry       time.Duration
+	Logger             log.Logger
+	tagErrors          prometheus.Counter
+	lastProcessed      prometheus.Gauge
+	sampleExpiryMetric prometheus.Gauge
+	invalidMetrics     prometheus.Counter
+}
+
+func NewGraphiteCollector(logger log.Logger, strictMatch bool, sampleExpiry time.Duration, tagErrors prometheus.Counter, lastProcessed prometheus.Gauge, sampleExpiryMetric prometheus.Gauge, invalidMetrics prometheus.Counter) *graphiteCollector {
+	c := &graphiteCollector{
+		SampleCh:           make(chan *graphitesample.GraphiteSample),
+		lineCh:             make(chan string),
+		mu:                 &sync.Mutex{},
+		Samples:            map[string]*graphitesample.GraphiteSample{},
+		StrictMatch:        strictMatch,
+		sampleExpiry:       sampleExpiry,
+		Logger:             logger,
+		tagErrors:          tagErrors,
+		lastProcessed:      lastProcessed,
+		sampleExpiryMetric: sampleExpiryMetric,
+		invalidMetrics:     invalidMetrics,
+	}
+
+	go c.processSamples()
+	go c.processLines()
+
+	return c
+}
+
+func (c *graphiteCollector) ProcessReader(reader io.Reader) {
+	lineScanner := bufio.NewScanner(reader)
+
+	for {
+		if ok := lineScanner.Scan(); !ok {
+			break
+		}
+		c.lineCh <- lineScanner.Text()
+	}
+}
+
+func (c *graphiteCollector) processLines() {
+	for l := range c.lineCh {
+		line.ProcessLine(l, c.Mapper, c.SampleCh, c.StrictMatch, c.tagErrors, c.lastProcessed, c.invalidMetrics, c.Logger)
+	}
+}
+
+func (c *graphiteCollector) processSamples() {
+	ticker := time.NewTicker(time.Minute).C
+
+	for {
+		select {
+		case sample, ok := <-c.SampleCh:
+			if sample == nil || !ok {
+				return
+			}
+
+			c.mu.Lock()
+			c.Samples[sample.OriginalName] = sample
+			c.mu.Unlock()
+		case <-ticker:
+			// Garbage collect expired Samples.
+			ageLimit := time.Now().Add(-c.sampleExpiry)
+
+			c.mu.Lock()
+			for k, sample := range c.Samples {
+				if ageLimit.After(sample.Timestamp) {
+					delete(c.Samples, k)
+				}
+			}
+			c.mu.Unlock()
+		}
+	}
+}
+
+// Collect implements prometheus.Collector.
+func (c graphiteCollector) Collect(ch chan<- prometheus.Metric) {
+	ch <- c.lastProcessed
+
+	c.mu.Lock()
+	level.Debug(c.Logger).Log("msg", "Samples length", "len", len(c.Samples))
+	samples := make([]*graphitesample.GraphiteSample, 0, len(c.Samples))
+
+	for _, sample := range c.Samples {
+		samples = append(samples, sample)
+	}
+	c.mu.Unlock()
+
+	ageLimit := time.Now().Add(-c.sampleExpiry)
+
+	for _, sample := range samples {
+		if ageLimit.After(sample.Timestamp) {
+			continue
+		}
+		ch <- prometheus.MustNewConstMetric(
+			prometheus.NewDesc(sample.Name, sample.Help, []string{}, sample.Labels),
+			sample.Type,
+			sample.Value,
+		)
+	}
+}
+
+// Describe implements prometheus.Collector.
+func (c graphiteCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.lastProcessed.Desc()
+}

--- a/pkg/graphitesample/graphitesample.go
+++ b/pkg/graphitesample/graphitesample.go
@@ -1,0 +1,36 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graphitesample
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// GraphiteSample represents a graphite metric sample
+type GraphiteSample struct {
+	OriginalName string
+	Name         string
+	Labels       prometheus.Labels
+	Help         string
+	Value        float64
+	Type         prometheus.ValueType
+	Timestamp    time.Time
+}
+
+func (s GraphiteSample) String() string {
+	return fmt.Sprintf("%#v", s)
+}

--- a/pkg/line/line.go
+++ b/pkg/line/line.go
@@ -1,0 +1,190 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package line
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/statsd_exporter/pkg/mapper"
+
+	"github.com/prometheus/graphite_exporter/pkg/graphitesample"
+	"github.com/prometheus/graphite_exporter/pkg/metricmapper"
+)
+
+var (
+	invalidMetricChars  = regexp.MustCompile("[^a-zA-Z0-9_:]")
+	metricNameKeysIndex = newMetricNameAndKeys()
+)
+
+// metricNameAndKeys is a cache of metric names and the label keys previously used
+type metricNameAndKeys struct {
+	mtx   sync.Mutex
+	cache map[string]string
+}
+
+func newMetricNameAndKeys() *metricNameAndKeys {
+	x := metricNameAndKeys{
+		cache: make(map[string]string),
+	}
+
+	return &x
+}
+
+func keysFromLabels(labels prometheus.Labels) string {
+	labelKeys := make([]string, len(labels))
+	for k := range labels {
+		labelKeys = append(labelKeys, k)
+	}
+
+	sort.Strings(labelKeys)
+
+	return strings.Join(labelKeys, ",")
+}
+
+// checkNameAndKeys returns true if metric has the same label keys or is new, false if not
+func (c *metricNameAndKeys) checkNameAndKeys(name string, labels prometheus.Labels) bool {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	providedKeys := keysFromLabels(labels)
+
+	if keys, found := c.cache[name]; found {
+		return keys == providedKeys
+	}
+
+	c.cache[name] = providedKeys
+
+	return true
+}
+
+func parseMetricNameAndTags(name string, labels prometheus.Labels, tagErrors prometheus.Counter) (string, error) {
+	if strings.ContainsRune(name, ';') {
+		// name contains tags - parse tags and add to labels
+		if strings.Count(name, ";") != strings.Count(name, "=") {
+			tagErrors.Inc()
+			return name, fmt.Errorf("error parsing tags on %s", name)
+		}
+
+		parts := strings.Split(name, ";")
+		parsedName := parts[0]
+		tags := parts[1:]
+
+		for _, tag := range tags {
+			kv := strings.SplitN(tag, "=", 2)
+			if len(kv) != 2 {
+				// we may have added bad labels already...
+				tagErrors.Inc()
+				return name, fmt.Errorf("error parsing tags on %s", name)
+			}
+
+			k := kv[0]
+			v := kv[1]
+			labels[k] = v
+		}
+
+		return parsedName, nil
+	}
+
+	return name, nil
+}
+
+// ProcessLine takes a graphite metric line as a string, processes it into a GraphiteSample, and sends it to the sample channel
+func ProcessLine(line string, metricmapper metricmapper.MetricMapper, sampleCh chan *graphitesample.GraphiteSample, strictMatch bool, tagErrors prometheus.Counter, lastProcessed prometheus.Gauge, invalidMetrics prometheus.Counter, logger log.Logger) {
+	line = strings.TrimSpace(line)
+	level.Debug(logger).Log("msg", "Incoming line", "line", line)
+	parts := strings.Split(line, " ")
+
+	if len(parts) != 3 {
+		level.Info(logger).Log("msg", "Invalid part count", "parts", len(parts), "line", line)
+		return
+	}
+
+	originalName := parts[0]
+
+	var name string
+	var err error
+
+	mapping, labels, mappingPresent := metricmapper.GetMapping(originalName, mapper.MetricTypeGauge)
+
+	if (mappingPresent && mapping.Action == mapper.ActionTypeDrop) || (!mappingPresent && strictMatch) {
+		return
+	}
+
+	if mappingPresent {
+		parsedLabels := make(prometheus.Labels)
+
+		if _, err = parseMetricNameAndTags(originalName, parsedLabels, tagErrors); err != nil {
+			level.Info(logger).Log("msg", "Invalid tags", "line", line)
+			return
+		}
+
+		name = invalidMetricChars.ReplaceAllString(mapping.Name, "_")
+		// check to ensure the same tags are present
+		if validKeys := metricNameKeysIndex.checkNameAndKeys(name, parsedLabels); !validKeys {
+			level.Info(logger).Log("msg", "Dropped because metric keys do not match previously used keys", "line", line)
+			invalidMetrics.Inc()
+
+			return
+		}
+	} else {
+		labels = make(prometheus.Labels)
+		name, err = parseMetricNameAndTags(originalName, labels, tagErrors)
+		if err != nil {
+			level.Info(logger).Log("msg", "Invalid tags", "line", line)
+			return
+		}
+		name = invalidMetricChars.ReplaceAllString(name, "_")
+		// check to ensure the same tags are present
+		if validKeys := metricNameKeysIndex.checkNameAndKeys(name, labels); !validKeys {
+			level.Info(logger).Log("msg", "Dropped because metric keys do not match previously used keys", "line", line)
+			invalidMetrics.Inc()
+			return
+		}
+	}
+
+	value, err := strconv.ParseFloat(parts[1], 64)
+	if err != nil {
+		level.Info(logger).Log("msg", "Invalid value", "line", line)
+		return
+	}
+
+	timestamp, err := strconv.ParseFloat(parts[2], 64)
+	if err != nil {
+		level.Info(logger).Log("msg", "Invalid timestamp", "line", line)
+		return
+	}
+
+	sample := graphitesample.GraphiteSample{
+		OriginalName: originalName,
+		Name:         name,
+		Value:        value,
+		Labels:       labels,
+		Type:         prometheus.GaugeValue,
+		Help:         fmt.Sprintf("Graphite metric %s", name),
+		Timestamp:    time.Unix(int64(timestamp), int64(math.Mod(timestamp, 1.0)*1e9)),
+	}
+	level.Debug(logger).Log("msg", "Processing sample", "sample", sample)
+	lastProcessed.Set(float64(time.Now().UnixNano()) / 1e9)
+	sampleCh <- &sample
+}

--- a/pkg/line/line.go
+++ b/pkg/line/line.go
@@ -110,7 +110,7 @@ func parseMetricNameAndTags(name string, labels prometheus.Labels, tagErrors pro
 }
 
 // ProcessLine takes a graphite metric line as a string, processes it into a GraphiteSample, and sends it to the sample channel
-func ProcessLine(line string, metricmapper metricmapper.MetricMapper, sampleCh chan *graphitesample.GraphiteSample, strictMatch bool, tagErrors prometheus.Counter, lastProcessed prometheus.Gauge, invalidMetrics prometheus.Counter, logger log.Logger) {
+func ProcessLine(line string, metricmapper metricmapper.MetricMapper, sampleCh chan<- *graphitesample.GraphiteSample, strictMatch bool, tagErrors prometheus.Counter, lastProcessed prometheus.Gauge, invalidMetrics prometheus.Counter, logger log.Logger) {
 	line = strings.TrimSpace(line)
 	level.Debug(logger).Log("msg", "Incoming line", "line", line)
 	parts := strings.Split(line, " ")

--- a/pkg/line/line_test.go
+++ b/pkg/line/line_test.go
@@ -1,0 +1,66 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package line
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseNameAndTags(t *testing.T) {
+	type testCase struct {
+		line       string
+		parsedName string
+		labels     prometheus.Labels
+		willFail   bool
+	}
+
+	testCases := []testCase{
+		{
+			line:       "my_simple_metric_with_tags;tag1=value1;tag2=value2",
+			parsedName: "my_simple_metric_with_tags",
+			labels: prometheus.Labels{
+				"tag1": "value1",
+				"tag2": "value2",
+			},
+		},
+		{
+			line:       "my_simple_metric_with_bad_tags;tag1=value1;tag2",
+			parsedName: "my_simple_metric_with_bad_tags;tag1=value1;tag2",
+			labels:     prometheus.Labels{},
+			willFail:   true,
+		},
+	}
+
+	tagErrorsTest := prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "graphite_tag_parse_errors_test",
+			Help: "Total count of samples with invalid tags",
+		},
+	)
+
+	for _, testCase := range testCases {
+		labels := prometheus.Labels{}
+		n, err := parseMetricNameAndTags(testCase.line, labels, tagErrorsTest)
+
+		if !testCase.willFail {
+			assert.NoError(t, err, "Got unexpected error parsing %s", testCase.line)
+		}
+
+		assert.Equal(t, testCase.parsedName, n)
+		assert.Equal(t, testCase.labels, labels)
+	}
+}

--- a/pkg/metricmapper/mapper.go
+++ b/pkg/metricmapper/mapper.go
@@ -1,0 +1,26 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metricmapper
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/statsd_exporter/pkg/mapper"
+)
+
+// MetricMapper is an interface for mapper methods
+type MetricMapper interface {
+	GetMapping(string, mapper.MetricType) (*mapper.MetricMapping, prometheus.Labels, bool)
+	InitFromFile(string, int, ...mapper.CacheOption) error
+	InitCache(int, ...mapper.CacheOption)
+}


### PR DESCRIPTION
Initial hacking for supporting graphite tags. 

This draft is very rough - I'll spend some time looking it over and making improvement, but wanted to get some feedback before going any further. I'm not too familiar with this exporter, so some of my assumptions may be wrong

In order to keep metric labels consistent, I added a simple cache of metric names and label keys previously encountered. Metrics sent with inconsistent label keys will be dropped and a metric incremented.

The e2e tests were already broken, so I didn't touch them.
Fixes #36 
@matthiasr 