### PR TITLE
simple graphite tags support

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,11 @@
 run:
   modules-download-mode: vendor
-
+  skip-dirs:
+    - vendor
+    - e2e
 # Run only staticcheck for now. Additional linters will be enabled one-by-one.
 linters:
   enable:
   - staticcheck
+  - goimports
   disable-all: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,7 @@ run:
   skip-dirs:
     - vendor
     - e2e
-# Run only staticcheck for now. Additional linters will be enabled one-by-one.
+# Run only staticcheck and goimports for now. Additional linters will be enabled one-by-one.
 linters:
   enable:
   - staticcheck

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Metrics will be available on [http://localhost:9108/metrics](http://localhost:91
 To avoid using unbounded memory, metrics will be garbage collected five minutes after
 they are last pushed to. This is configurable with the `--graphite.sample-expiry` flag.
 
+## Graphite Tags
+The graphite_exporter accepts metrics in the [tagged carbon format](https://graphite.readthedocs.io/en/latest/tags.html). Labels specified in the mapping configuration take precedence over tags in the metric. In the case where there are valid and invalid tags supplied in one metric, the invalid tags will be dropped and the `graphite_tag_parse_failures` counter will be incremented. The exporter accepts inconsistent label sets, but this may cause issues querying the data in Prometheus.
+
 ## Metric Mapping and Configuration
 
 **Please note there has been a breaking change in configuration after version 0.2.0.  The YAML style config from [statsd_exporter](https://github.com/prometheus/statsd_exporter) is now used.  See conversion instructions below**

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -193,3 +193,81 @@ rspamd.spam_count 3 NOW`
 		}
 	}
 }
+
+// Test to ensure that inconsistent label sets are accepted and exported correctly
+func TestInconsistentLabelsE2E(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	webAddr, graphiteAddr := fmt.Sprintf("127.0.0.1:%d", 9108), fmt.Sprintf("127.0.0.1:%d", 9109)
+	exporter := exec.Command(
+		filepath.Join(cwd, "..", "graphite_exporter"),
+		"--web.listen-address", webAddr,
+		"--graphite.listen-address", graphiteAddr,
+		"--graphite.mapping-config", filepath.Join(cwd, "fixtures", "mapping.yml"),
+	)
+	err = exporter.Start()
+	if err != nil {
+		t.Fatalf("execution error: %v", err)
+	}
+	defer exporter.Process.Kill()
+
+	for i := 0; i < 20; i++ {
+		if i > 0 {
+			time.Sleep(1 * time.Second)
+		}
+		resp, err := http.Get("http://" + webAddr)
+		if err != nil {
+			continue
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode == http.StatusOK {
+			break
+		}
+	}
+
+	now := time.Now()
+
+	input := `rspamd.actions;action=add_header 2 NOW
+rspamd.actions;action=greylist 0 NOW
+rspamd.actions;action2=add_header 2 NOW
+rspamd.actions;action2=greylist 0 NOW
+`
+	input = strings.NewReplacer("NOW", fmt.Sprintf("%d", now.Unix())).Replace(input)
+
+	output := []string{
+		"rspamd_actions{action=\"add_header\"} 2",
+		"rspamd_actions{action=\"greylist\"} 0",
+		"rspamd_actions{action2=\"add_header\"} 2",
+		"rspamd_actions{action2=\"greylist\"} 0",
+	}
+
+	conn, err := net.Dial("tcp", graphiteAddr)
+	if err != nil {
+		t.Fatalf("connection error: %v", err)
+	}
+	defer conn.Close()
+	_, err = conn.Write([]byte(input))
+	if err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+
+	time.Sleep(5 * time.Second)
+
+	resp, err := http.Get("http://" + path.Join(webAddr, "metrics"))
+	if err != nil {
+		t.Fatalf("get error: %v", err)
+	}
+	defer resp.Body.Close()
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read error: %v", err)
+	}
+	for _, s := range output {
+		if !strings.Contains(string(b), s) {
+			t.Fatalf("Expected %q in %q – input: %q – time: %s", s, string(b), input, now)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -68,11 +68,6 @@ var (
 			Name: "graphite_tag_parse_failures",
 			Help: "Total count of samples with invalid tags",
 		})
-	invalidMetrics = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Name: "graphite_invalid_metrics",
-			Help: "Total count of metrics dropped due to mismatched label keys",
-		})
 	invalidMetricChars = regexp.MustCompile("[^a-zA-Z0-9_:]")
 )
 
@@ -176,7 +171,7 @@ func (c *graphiteCollector) processLine(line string) {
 
 	parsedName, labels, err := parseMetricNameAndTags(originalName)
 	if err != nil {
-		level.Info(c.logger).Log("msg", "Invalid tags", "line", line, "err", err.Error())
+		level.Debug(c.logger).Log("msg", "Invalid tags", "line", line, "err", err.Error())
 	}
 
 	mapping, mappingLabels, mappingPresent := c.mapper.GetMapping(parsedName, mapper.MetricTypeGauge)
@@ -305,7 +300,6 @@ func main() {
 
 	prometheus.MustRegister(sampleExpiryMetric)
 	prometheus.MustRegister(tagParseFailures)
-	prometheus.MustRegister(invalidMetrics)
 	sampleExpiryMetric.Set(sampleExpiry.Seconds())
 
 	level.Info(logger).Log("msg", "Starting graphite_exporter", "version_info", version.Info())

--- a/main_benchmark_test.go
+++ b/main_benchmark_test.go
@@ -29,10 +29,10 @@ func benchmarkProcessLine(times int, b *testing.B) {
 	now := time.Now()
 
 	rawInput := `rspamd.actions.add_header 2 NOW
-rspamd.actions.greylist 0 NOW
-rspamd.actions.no_action 24 NOW
-rspamd.actions.reject 1 NOW
-rspamd.actions.rewrite_subject 0 NOW
+rspamd.actions;action=greylist 0 NOW
+rspamd.actions;action=no_action 24 NOW
+rspamd.actions;action=reject 1 NOW
+rspamd.actions;action=rewrite_subject 0 NOW
 rspamd.actions.soft_reject 0 NOW
 rspamd.bytes_allocated 4165268944 NOW
 rspamd.chunks_allocated 4294966730 NOW

--- a/main_test.go
+++ b/main_test.go
@@ -50,7 +50,7 @@ func TestParseNameAndTags(t *testing.T) {
 		line       string
 		parsedName string
 		labels     prometheus.Labels
-		willFail   bool
+		willError  bool
 	}
 
 	testCases := []testCase{
@@ -63,17 +63,28 @@ func TestParseNameAndTags(t *testing.T) {
 			},
 		},
 		{
-			line:       "my_simple_metric_with_bad_tags;tag1=value1;tag2",
-			parsedName: "my_simple_metric_with_bad_tags;tag1=value1;tag2",
-			labels:     prometheus.Labels{},
-			willFail:   true,
+			line:       "my_simple_metric_with_bad_tags;tag1=value3;tag2",
+			parsedName: "my_simple_metric_with_bad_tags",
+			labels:     prometheus.Labels{
+				"tag1": "value3",
+			},
+			willError: true,
+		},
+		{
+			line:       "my_simple_metric_with_bad_tags;tag1=value3;tag2;tag3=value4",
+			parsedName: "my_simple_metric_with_bad_tags",
+			labels:     prometheus.Labels{
+				"tag1": "value3",
+				"tag3": "value4",
+			},
+			willError: true,
 		},
 	}
 
 	for _, testCase := range testCases {
 		labels := prometheus.Labels{}
 		n, err := parseMetricNameAndTags(testCase.line, labels)
-		if !testCase.willFail {
+		if !testCase.willError {
 			assert.NoError(t, err, "Got unexpected error parsing %s", testCase.line)
 		}
 		assert.Equal(t, testCase.parsedName, n)

--- a/main_test.go
+++ b/main_test.go
@@ -124,16 +124,18 @@ func TestProcessLine(t *testing.T) {
 			mappingPresent: true,
 			value:          float64(9001),
 		},
-		"metric with different labels is dropped": {
-			// will fail since my_simple_metric has different label keys than in the previous test case
+		"existing metric with different labels is accepted": {
 			line: "my.simple.metric.baz 9002 1534620625",
 			name: "my_simple_metric",
 			mappingLabels: prometheus.Labels{
 				"baz": "bat",
 			},
+			sampleLabels: prometheus.Labels{
+				"baz": "bat",
+			},
 			mappingPresent: true,
 			value:          float64(9002),
-			willFail:       true,
+			willFail:       false,
 		},
 		"mapped metric": {
 			line: "my.simple.metric.new.baz 9002 1534620625",
@@ -219,12 +221,6 @@ func TestProcessLine(t *testing.T) {
 			},
 			mappingPresent: true,
 			value:          float64(9003),
-		},
-		"different tag keys will drop": {
-			// new tags other than previously used, should drop
-			line:     "my.simple.metric.with.tags;tag1=value1;tag3=value2 9002 1534620625",
-			name:     "my_simple_metric_with_tags",
-			willFail: true,
 		},
 	}
 


### PR DESCRIPTION
Simple implementation of graphite tag support without breaking out into packages.

Fixes #36 

Benchmark on master:
```
$ go test -bench=. 
goos: darwin
goarch: amd64
pkg: github.com/prometheus/graphite_exporter
BenchmarkProcessLine1-12           17187             69149 ns/op
BenchmarkProcessLine5-12            3506            343312 ns/op
BenchmarkProcessLine50-12            348           3451278 ns/op
PASS
ok      github.com/prometheus/graphite_exporter 4.920s
```

Benchmark with tag parsing:
```
$ go test -bench=. 
goos: darwin
goarch: amd64
pkg: github.com/prometheus/graphite_exporter
BenchmarkProcessLine1-12           15975             75466 ns/op
BenchmarkProcessLine5-12            3189            374342 ns/op
BenchmarkProcessLine50-12            318           3767328 ns/op
PASS
ok      github.com/prometheus/graphite_exporter 5.010s
```

The benchmark only replaces four metrics with tagged equivalents, so I am not sure how exact the parsing hit is... It may also be greater when there is a large number of metrics in the `metricNameAndKeys` cache. The cache was added to address the concerns about inconsistent label keys referenced in the original issue, but there may be a better way to do that.

@matthiasr 