### PR TITLE
improve benchmark validity by not measuring startup costs

### DIFF
--- a/main_benchmark_test.go
+++ b/main_benchmark_test.go
@@ -50,23 +50,17 @@ rspamd.spam_count 3 NOW`
 	rawInput = strings.NewReplacer("NOW", fmt.Sprintf("%d", now.Unix())).Replace(rawInput)
 	input := strings.Split(rawInput, "\n")
 
+	c.mapper = &mockMapper{
+		name:    "not_used",
+		present: false,
+	}
+
 	// reset benchmark timer to not measure startup costs
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
 		for i := 0; i < times; i++ {
 			for _, l := range input {
-				// pause benchmark timer for creating the mock mapper
-				b.StopTimer()
-
-				c.mapper = &mockMapper{
-					name:    "not_used",
-					present: false,
-				}
-
-				// resume benchmark timer
-				b.StartTimer()
-
 				c.processLine(l)
 			}
 		}

--- a/main_benchmark_test.go
+++ b/main_benchmark_test.go
@@ -50,13 +50,23 @@ rspamd.spam_count 3 NOW`
 	rawInput = strings.NewReplacer("NOW", fmt.Sprintf("%d", now.Unix())).Replace(rawInput)
 	input := strings.Split(rawInput, "\n")
 
+	// reset benchmark timer to not measure startup costs
+	b.ResetTimer()
+
 	for n := 0; n < b.N; n++ {
 		for i := 0; i < times; i++ {
 			for _, l := range input {
+				// pause benchmark timer for creating the mock mapper
+				b.StopTimer()
+
 				c.mapper = &mockMapper{
 					name:    "not_used",
 					present: false,
 				}
+
+				// resume benchmark timer
+				b.StartTimer()
+
 				c.processLine(l)
 			}
 		}


### PR DESCRIPTION
Modify benchmarks to not measure startup costs - https://dave.cheney.net/high-performance-go-workshop/dotgo-paris.html#avoiding_benchmarking_start_up_costs

This doesn't seem to affect the benchmark results too much, but seems more correct.

@matthiasr