### PR TITLE
Fix Whisper reader tests

### DIFF
--- a/reader/reader_test.go
+++ b/reader/reader_test.go
@@ -17,9 +17,16 @@ import (
 	"math"
 	"sort"
 	"testing"
+	"time"
 
+	"github.com/go-graphite/go-whisper"
 	"github.com/stretchr/testify/require"
 )
+
+func init() {
+	// Pin go-whisper to a fixed timestamp so that the test data is in the window of retention.
+	whisper.Now = func() time.Time { return time.Unix(1640000000, 0) }
+}
 
 func TestListMetrics(t *testing.T) {
 	reader := NewReader("testdata")


### PR DESCRIPTION
The tests were time dependent, as the samples in the test data aged out
of the time window. In tests, override go-whisper's notion of "now" to a
fixed time that is close enough so that all data is within the maximum
retention window.

Signed-off-by: Matthias Rampke <matthias@prometheus.io>