### PR TITLE
Pass a logger to the MetricMapper

### DIFF
--- a/cmd/graphite_exporter/main.go
+++ b/cmd/graphite_exporter/main.go
@@ -87,7 +87,7 @@ func main() {
 	c := collector.NewGraphiteCollector(logger, *strictMatch, *sampleExpiry)
 	prometheus.MustRegister(c)
 
-	metricMapper := &mapper.MetricMapper{}
+	metricMapper := &mapper.MetricMapper{Logger: logger}
 	if *mappingConfig != "" {
 		err := metricMapper.InitFromFile(*mappingConfig)
 		if err != nil {

--- a/e2e/fixtures/backtrack.yml
+++ b/e2e/fixtures/backtrack.yml
@@ -1,0 +1,8 @@
+mappings:
+- match: a.*.*.b
+  name: axxb
+  labels:
+    one: $1
+    two: $2
+- match: a.b.c.d
+  name: abcd


### PR DESCRIPTION
Fixes https://github.com/prometheus/graphite_exporter/issues/197.

Ensures that warnings from mapping are visible.

Add and end-to-end test that uses a backtracking configuration.