### PR TITLE
Remove ioutil

### DIFF
--- a/cmd/getool/backfill_test.go
+++ b/cmd/getool/backfill_test.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"math"
 	"os"
 	"os/exec"
@@ -58,7 +58,7 @@ func TestBackfill(t *testing.T) {
 	stderr, err := cmd.StderrPipe()
 	require.NoError(t, err)
 	go func() {
-		slurp, _ := ioutil.ReadAll(stderr)
+		slurp, _ := io.ReadAll(stderr)
 		t.Log(string(slurp))
 	}()
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -15,7 +15,7 @@ package e2e
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -100,7 +100,7 @@ rspamd.spam_count 3 NOW`
 		t.Fatalf("get error: %v", err)
 	}
 	defer resp.Body.Close()
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("read error: %v", err)
 	}
@@ -183,7 +183,7 @@ rspamd.spam_count 3 NOW`
 		t.Fatalf("get error: %v", err)
 	}
 	defer resp.Body.Close()
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("read error: %v", err)
 	}
@@ -261,7 +261,7 @@ rspamd.actions;action2=greylist 0 NOW
 		t.Fatalf("get error: %v", err)
 	}
 	defer resp.Body.Close()
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("read error: %v", err)
 	}
@@ -339,7 +339,7 @@ a.b.c.d 4 NOW
 		t.Fatalf("get error: %v", err)
 	}
 	defer resp.Body.Close()
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("read error: %v", err)
 	}

--- a/e2e/issue90_test.go
+++ b/e2e/issue90_test.go
@@ -16,7 +16,7 @@ package e2e
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -62,7 +62,7 @@ func TestIssue90(t *testing.T) {
 		}
 	}
 
-	testInputs, err := ioutil.ReadFile(filepath.Join(cwd, "fixtures", "issue90_in.txt"))
+	testInputs, err := os.ReadFile(filepath.Join(cwd, "fixtures", "issue90_in.txt"))
 	if err != nil {
 		t.Fatalf("failed to read input fixture: %v", err)
 	}
@@ -90,7 +90,7 @@ func TestIssue90(t *testing.T) {
 		t.Fatalf("get error: %v", err)
 	}
 	defer resp.Body.Close()
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("read error: %v", err)
 	}


### PR DESCRIPTION
`ioutil` is deprecated from go1.16 (ref: https://go.dev/doc/go1.16#ioutil).
So removed them.

Signed-off-by: inosato <si17_21@yahoo.co.jp>