### PR TITLE
Update Prometheus common orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  prometheus: prometheus/prometheus@0.16.0
+  prometheus: prometheus/prometheus@0.17.1
 executors:
   # Whenever the Go version is updated here, .promu.yml should also be updated.
   golang:


### PR DESCRIPTION
to fix issues with binfmt after the CircleCI infrastructure migration