### PR TITLE
use Go standard errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,12 @@ run:
 # Run only staticcheck and goimports for now. Additional linters will be enabled one-by-one.
 linters:
   enable:
-  - staticcheck
-  - goimports
+    - errorlint
+    - gofumpt
+    - goimports
+    - staticcheck
   disable-all: true
+
+linters-settings:
+  goimports:
+    local-prefixes: github.com/prometheus/graphite_exporter

--- a/cmd/getool/backfill_test.go
+++ b/cmd/getool/backfill_test.go
@@ -43,7 +43,7 @@ func TestBackfill(t *testing.T) {
 		whisperDir = filepath.Join(tmpData, "whisper", "load", "cpu")
 	)
 
-	require.NoError(t, os.MkdirAll(whisperDir, 0777))
+	require.NoError(t, os.MkdirAll(whisperDir, 0o777))
 	retentions, err := whisper.ParseRetentionDefs("1s:3600")
 	require.NoError(t, err)
 	wsp, err := whisper.Create(filepath.Join(whisperDir, "cpu0.wsp"), retentions, whisper.Sum, 0.5)
@@ -68,7 +68,7 @@ func TestBackfill(t *testing.T) {
 	err = cmd.Wait()
 	require.NoError(t, err)
 
-	require.NoError(t, os.MkdirAll(filepath.Join(tmpData, "data", "wal"), 0777))
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpData, "data", "wal"), 0o777))
 
 	db, err := tsdb.OpenDBReadOnly(filepath.Join(tmpData, "data"), nil)
 	require.NoError(t, err)

--- a/cmd/getool/main_test.go
+++ b/cmd/getool/main_test.go
@@ -19,8 +19,10 @@ import (
 	"testing"
 )
 
-var testPath = os.Args[0]
-var tmpData = filepath.Join(os.TempDir(), "graphite_expoter_test")
+var (
+	testPath = os.Args[0]
+	tmpData  = filepath.Join(os.TempDir(), "graphite_expoter_test")
+)
 
 func TestMain(m *testing.M) {
 	for i, arg := range os.Args {

--- a/cmd/graphite_exporter/main.go
+++ b/cmd/graphite_exporter/main.go
@@ -33,10 +33,11 @@ import (
 	"github.com/prometheus/common/version"
 	"github.com/prometheus/exporter-toolkit/web"
 	"github.com/prometheus/exporter-toolkit/web/kingpinflag"
-	"github.com/prometheus/graphite_exporter/collector"
 	"github.com/prometheus/statsd_exporter/pkg/mapper"
 	"github.com/prometheus/statsd_exporter/pkg/mappercache/lru"
 	"github.com/prometheus/statsd_exporter/pkg/mappercache/randomreplacement"
+
+	"github.com/prometheus/graphite_exporter/collector"
 )
 
 var (

--- a/collector/collector_benchmark_test.go
+++ b/collector/collector_benchmark_test.go
@@ -65,11 +65,8 @@ type mockMapper struct {
 }
 
 func (m *mockMapper) GetMapping(metricName string, metricType mapper.MetricType) (*mapper.MetricMapping, prometheus.Labels, bool) {
-
 	mapping := mapper.MetricMapping{Name: m.name, Action: m.action}
-
 	return &mapping, m.labels, m.present
-
 }
 
 func (m *mockMapper) InitFromFile(string) error {
@@ -106,9 +103,11 @@ func benchmarkProcessLine(b *testing.B, line string) {
 func BenchmarkProcessLineMixed1(b *testing.B) {
 	benchmarkProcessLines(1, b, input)
 }
+
 func BenchmarkProcessLineMixed5(b *testing.B) {
 	benchmarkProcessLines(5, b, input)
 }
+
 func BenchmarkProcessLineMixed50(b *testing.B) {
 	benchmarkProcessLines(50, b, input)
 }
@@ -117,6 +116,7 @@ func BenchmarkProcessLineMixed50(b *testing.B) {
 func BenchmarkProcessLineUntagged(b *testing.B) {
 	benchmarkProcessLine(b, untaggedLine)
 }
+
 func BenchmarkProcessLineTagged(b *testing.B) {
 	benchmarkProcessLine(b, taggedLine)
 }

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -75,7 +75,6 @@ func TestParseNameAndTags(t *testing.T) {
 }
 
 func TestProcessLine(t *testing.T) {
-
 	type testCase struct {
 		line           string
 		name           string

--- a/e2e/issue90_test.go
+++ b/e2e/issue90_test.go
@@ -98,5 +98,4 @@ func TestIssue90(t *testing.T) {
 	if resp.StatusCode != 200 {
 		t.Errorf("unexpected status, want 200, got %v, body: %s", resp.Status, b)
 	}
-
 }

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/alecthomas/units v0.0.0-20231202071711-9a357b53e9c9
 	github.com/go-graphite/go-whisper v0.0.0-20230526115116-e3110f57c01c
 	github.com/go-kit/log v0.2.1
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.19.0
 	github.com/prometheus/common v0.49.0
 	github.com/prometheus/exporter-toolkit v0.11.0
@@ -31,6 +30,7 @@ require (
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect


### PR DESCRIPTION
* Since Dec 1, 2021, github.com/pkg/errors is an archived project.
* Since go 1.13, there is a standard errors and fmt modules that provides equivalent ways to handle errors.

Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>