### PR TITLE
Remove gofumpt linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,6 @@ run:
 linters:
   enable:
     - errorlint
-    - gofumpt
     - goimports
     - staticcheck
   disable-all: true


### PR DESCRIPTION
`gofmt` is the common standard. It is good enough.