### PR TITLE
Add Pedro Tanaka as co-maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,1 +1,2 @@
 * Matthias Rampke <matthias@prometheus.io>
+* Pedro Tanaka [@pedro-stanaka](https://github.com/pedro-stanaka)


### PR DESCRIPTION
Pedro runs [one of the largest statsd-exporter
installations](https://promcon.io/2023-berlin/talks/taming-the-tsunami-low-latency-ingestion-of-push-based-metrics-in-prometheus/).
Considering how close the two exporters are, I am keeping maintainership in
sync.

Thank you Pedro for agreeing to help out!

Cf: https://github.com/prometheus/statsd_exporter/pull/594
Signed-off-by: Matthias Rampke <matthias@prometheus.io>