### PR TITLE
Update backfill to generate blocks with sorted labels

### DIFF
--- a/cmd/getool/backfill.go
+++ b/cmd/getool/backfill.go
@@ -23,6 +23,7 @@ import (
 	"math"
 	"os"
 	"regexp"
+	"sort"
 	"strconv"
 	"text/tabwriter"
 	"time"
@@ -85,10 +86,6 @@ func createBlocks(input reader.DBReader, mint, maxt, blockDuration int64, maxSam
 				}
 
 				l := make(labels.Labels, 0)
-				// add mapping labels to parsed labels·
-				for k, v := range mappingLabels {
-					l = append(l, labels.Label{Name: k, Value: v})
-				}
 
 				var name string
 				if mappingPresent {
@@ -97,6 +94,16 @@ func createBlocks(input reader.DBReader, mint, maxt, blockDuration int64, maxSam
 					name = invalidMetricChars.ReplaceAllString(m, "_")
 				}
 				l = append(l, labels.Label{Name: "__name__", Value: name})
+
+				keys := make([]string, 0, len(mappingLabels))
+				for k := range mappingLabels {
+					keys = append(keys, k)
+				}
+				sort.Strings(keys)
+				// add mapping labels to parsed labels·
+				for _, k := range keys {
+					l = append(l, labels.Label{Name: k, Value: mappingLabels[k]})
+				}
 
 				points, err := input.Points(m, t, tsUpper)
 				if err != nil {

--- a/cmd/getool/backfill_test.go
+++ b/cmd/getool/backfill_test.go
@@ -56,9 +56,10 @@ mappings:
 - match: "load.*.*"
   name: load_$1
   labels:
+    state: idle
     cpu: $2`,
 			metricName: "load_cpu",
-			labels:     map[string]string{"cpu": "cpu0"},
+			labels:     map[string]string{"cpu": "cpu0", "state": "idle"},
 		},
 		{
 			name:        "strict_match",
@@ -136,13 +137,15 @@ mappings:
 
 			s := queryAllSeries(t, q)
 
-			// XXX: getool creates labels with the __name__ last, different from
-			// the sorting produced by labels.New. Is this a problem?
 			ll := labels.FromMap(tt.labels)
-			ll = append(ll, labels.Label{
-				Name:  "__name__",
-				Value: tt.metricName,
-			})
+
+			//Prepend the label __name__ to match expected order
+			ll = append([]labels.Label{
+				{
+					Name:  "__name__",
+					Value: tt.metricName,
+				},
+			}, ll...)
 
 			require.Equal(t, ll, s[0].Labels)
 			require.Equal(t, 1000*int64(metricTime-1), s[0].Timestamp)


### PR DESCRIPTION
When trying to import the generated blocks into Grafana Mimir, validation checks failed with an "out-of-order-labels" error.
This PR makes sure labels in the generated blocks are sorted and allows for the data to be backfilled using the mimirtool.

@matthiasr, @pedro-stanaka